### PR TITLE
Add v1_rotate_180 import option and project settings default

### DIFF
--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -28,12 +28,14 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     var bone_rename: int = options.get(&"vrm/bone_rename", 0) as int
     var skeleton_name: String = options.get(&"vrm/skeleton_name", "Skeleton3D") as String
     var remove_end: bool = options.get(&"vrm/remove_end_bones", true) as bool
+    var v1_rotate_180: bool = options.get(&"vrm/v1_rotate_180", true) as bool
 
     if not override_global:
         head_hiding = ProjectSettings.get_setting("vrm/import/head_hiding_method", head_hiding)
         bone_rename = ProjectSettings.get_setting("vrm/import/bone_rename", bone_rename)
         skeleton_name = ProjectSettings.get_setting("vrm/import/skeleton_name", skeleton_name)
         remove_end = ProjectSettings.get_setting("vrm/import/remove_end_bones", remove_end)
+        v1_rotate_180 = ProjectSettings.get_setting("vrm/import/v1_rotate_180", v1_rotate_180)
 
     state.set_additional_data(
         &"vrm/head_hiding_method", head_hiding as vrm_constants.HeadHidingSetting
@@ -51,6 +53,8 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     state.set_meta(&"vrm_third_person_layers", true)
     state.set_additional_data(&"vrm/remove_end_bones", remove_end)
     state.set_meta(&"vrm_remove_end_bones", true)
+    state.set_additional_data(&"vrm/v1_rotate_180", v1_rotate_180)
+    state.set_meta(&"vrm_v1_rotate_180", true)
     state.set_meta(&"vrm_bone_rename", bone_rename)
     state.set_meta(&"vrm_skeleton_name", skeleton_name)
     # HANDLE_BINARY_EMBED_AS_BASISU crashes on some files in 4.0 and 4.1

--- a/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
+++ b/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
@@ -47,3 +47,8 @@ func _get_import_options(path: String):
             "vrm/remove_end_bones",
             true
         )
+        add_import_option_advanced(
+            TYPE_BOOL,
+            "vrm/v1_rotate_180",
+            true
+        )

--- a/addons/vrm/importer/common/vrm_utils.gd
+++ b/addons/vrm/importer/common/vrm_utils.gd
@@ -125,6 +125,7 @@ static func apply_default_import_settings(gstate: GLTFState) -> void:
         &"vrm_first_person_layers": [&"vrm/first_person_layers", 2],
         &"vrm_third_person_layers": [&"vrm/third_person_layers", 4],
         &"vrm_remove_end_bones": [&"vrm/remove_end_bones", true],
+        &"vrm_v1_rotate_180": [&"vrm/v1_rotate_180", true],
     }
     
     for meta_key in additional_data_defaults:

--- a/addons/vrm/importer/v1/vrmc/vrmc_vrm.gd
+++ b/addons/vrm/importer/v1/vrmc/vrmc_vrm.gd
@@ -235,7 +235,9 @@ func _import_post(gstate: GLTFState, node: Node) -> Error:
 
     root_node.set_script(vrm_instance)
     if root_node is Node3D:
-        root_node.rotation.y = PI
+        var rotate_180 = gstate.get_additional_data(&"vrm/v1_rotate_180")
+        if rotate_180 == null or rotate_180:
+            root_node.rotation.y = PI
 
     var vrm_meta: Resource = _create_meta(
         root_node,

--- a/addons/vrm/plugin.gd
+++ b/addons/vrm/plugin.gd
@@ -59,6 +59,11 @@ func register_import_settings() -> void:
             "hint": PROPERTY_HINT_NONE,
             "default": true,
         },
+        "vrm/import/v1_rotate_180": {
+            "type": TYPE_BOOL,
+            "hint": PROPERTY_HINT_NONE,
+            "default": true,
+        },
     }
     for setting_name in import_settings:
         if not ProjectSettings.has_setting(setting_name):

--- a/tests/test_vrm1_import.gd
+++ b/tests/test_vrm1_import.gd
@@ -542,6 +542,55 @@ func test_vrm1_root_node_rotation():
     test_completed = true
 
 
+func test_vrm1_import_without_rotation():
+    var gltf = GLTFDocument.new()
+    var extensions = [
+        VRMC_NODE_CONSTRAINT.new(),
+        VRMC_SPRING_BONE.new(),
+        VRMC_MTOON.new(),
+        VRMC_HDR_EMISSIVE.new(),
+        VRMC_VRM.new(),
+        VRMC_VRM_ANIMATION.new(),
+    ]
+
+    for ext in extensions:
+        GLTFDocument.register_gltf_document_extension(ext, true)
+
+    var state := GLTFState.new()
+    const VRMConstants = preload("res://addons/vrm/core/vrm_constants.gd")
+    state.set_additional_data(
+        &"vrm/head_hiding_method", VRMConstants.HeadHidingSetting.ThirdPersonOnly
+    )
+    state.set_meta(&"vrm_head_hiding_method", true)
+    state.set_additional_data(&"vrm/first_person_layers", 2)
+    state.set_meta(&"vrm_first_person_layers", true)
+    state.set_additional_data(&"vrm/third_person_layers", 4)
+    state.set_meta(&"vrm_third_person_layers", true)
+    state.set_additional_data(&"vrm/remove_end_bones", true)
+    state.set_meta(&"vrm_remove_end_bones", true)
+    state.set_meta(&"vrm_skeleton_name", "Skeleton3D")
+    state.set_additional_data(&"vrm/v1_rotate_180", false)
+    state.set_meta(&"vrm_v1_rotate_180", true)
+
+    var err = gltf.append_from_file(VRM_FILE, state, 8)
+    assert_eq(err, OK, "Import with rotation disabled must succeed")
+    if err == OK:
+        var scene = gltf.generate_scene(state)
+        assert_not_null(scene, "Generated scene must not be null")
+        if scene is Node3D:
+            var y_rot = scene.rotation_degrees.y
+            assert_true(
+                abs(y_rot) < 0.1,
+                "VRM instance root node must NOT be rotated by 180 degrees around Y (got %f)" % y_rot
+            )
+        if scene:
+            scene.free()
+
+    for ext in extensions:
+        GLTFDocument.unregister_gltf_document_extension(ext)
+    test_completed = true
+
+
 func test_vrm1_import_none_bone_rename():
     var gltf = GLTFDocument.new()
     var extensions = [


### PR DESCRIPTION
This PR adds a new import setting vrm/v1_rotate_180 to specify whether the imported VRM v1 character should be rotated by 180 degrees around the Y-axis. It also adds a corresponding global default setting vrm/import/v1_rotate_180 which defaults to true.