### PR TITLE
feat: add clear_bone_rotation import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,51 +192,40 @@ In the debug images above:
 
 ## Import Options
 
-Available in the Import dock when selecting a `.vrm` file:
+Available in the Import dock when selecting a `.vrm` file (under **Advanced** mode):
 
-- **Head Hiding Method**: `ThirdPersonOnly` / `FirstPersonOnly` / `FirstWithShadow` / `Layers` / `LayersWithShadow` / `IgnoreHeadHiding`
-- **First/Third Person Layers**: Render layer masks for `Layers` mode
-- **Bone Rename**: See [Bone Rename Modes](#bone-rename-modes) below
-- **Skeleton Name**: Sets the skeleton node name (default `Skeleton3D`).
-     - Use `Skeleton3D` if:
-          - You are working with a Blender workflow (matches `.blend` import names).
-     - Use `GeneralSkeleton` if:
-          - You are working with standard Godot `BoneMap` profiles.
-- **Remove End Bones**: Strips empty end-bone nodes from the skeleton
+| Option | Default | Description |
+| ------ | :-----: | ----------- |
+| **Head Hiding Method** | `ThirdPersonOnly` | How first-person head meshes are handled: `ThirdPersonOnly`, `FirstPersonOnly`, `FirstWithShadow`, `Layers`, `LayersWithShadow`, `IgnoreHeadHiding` |
+| **First/Third Person Layers** | `2` / `4` | Render layer masks used when Head Hiding is set to `Layers` mode |
+| **Bone Rename** | `None` | How bones are renamed during import — see [Bone Rename Modes](#bone-rename-modes) |
+| **Skeleton Name** | `Skeleton3D` | Skeleton node name. Use `Skeleton3D` for Blender workflows, `GeneralSkeleton` for standard `BoneMap` profiles |
+| **Remove End Bones** | `true` | Strips empty `_end` marker nodes from the skeleton |
+| **V1 Rotate 180** | `true` | Rotates VRM 1.0 root node 180° around Y |
+| **Clear Bone Rotation** | `true` | Sets all bone rest rotations to identity `(0,0,0,1)` — useful when the T-pose has unwanted rotation from retargeting |
 
 ### Global Defaults
 
-> [!NOTE]
-> Import options are shown under the **Advanced** mode.
+Set defaults in **Project Settings → General → VRM → Import** instead of configuring per-file:
 
-Set default import options once in **Project Settings → General → VRM → Import** instead of configuring per-file:
-
-- `vrm/import/head_hiding_method` — Head hiding mode
-- `vrm/import/bone_rename` — Bone rename mode
-- `vrm/import/skeleton_name` — Skeleton node name
-- `vrm/import/remove_end_bones` — Remove end bones
+| Setting | Default | Description |
+| ------- | :-----: | ----------- |
+| `vrm/import/head_hiding_method` | `0` | Head hiding mode |
+| `vrm/import/bone_rename` | `0` | Bone rename mode |
+| `vrm/import/skeleton_name` | `Skeleton3D` | Skeleton node name |
+| `vrm/import/remove_end_bones` | `true` | Remove end bones |
+| `vrm/import/v1_rotate_180` | `true` | Rotate VRM 1.0 root 180° on Y |
+| `vrm/import/clear_bone_rotation` | `true` | Clear bone rest rotations to identity |
 
 In the import dialog, **Use Global Defaults** (enabled by default) reads from these project settings. Uncheck it to override settings for a specific file.
 
 ### Bone Rename Modes
 
-**None (Blender ready)**
-
-- Animate in Blender with the VRM addon
-- Import `.blend` files directly into Godot
-
-**Humanoid**
-
-- Standard Godot humanoid bone names (`Hips`, `Spine`, etc.)
-- Retarget animations across different avatars
-- Export from Godot and re-import via glTF
-- ⚠️ Works but not yet fully tested — may need extra setup
-
-**Symmetrize VRoid**
-
-- For VRoid Studio models
-- Symmetrize bones in Blender first
-- Blender menu: Armature → Object → VRM → Humanoid → Symmetrize VRoid Bone Names on X-Axis
+| Mode | Best for |
+| :--- | :------- |
+| **None (Blender ready)** | Animate in Blender with the VRM addon, import `.blend` files directly into Godot |
+| **Humanoid** | Standard Godot humanoid bone names (`Hips`, `Spine`, …). Retarget animations across avatars. ⚠️ Not yet fully tested |
+| **Symmetrize VRoid** | VRoid Studio models. Symmetrize bones in Blender first: Armature → Object → VRM → Humanoid → Symmetrize VRoid Bone Names on X-Axis |
 
 ### Works with Blender
 
@@ -250,11 +239,10 @@ For a smooth Blender ↔ Godot animation workflow:
 **Godot import settings for Blender workflow:**
 
 - **Bone Rename**: `None (Blender ready)` or `Symmetrize VRoid` (for VRoid models)
-- **Skeleton Name**:
-     - Use `Skeleton3D` (default) if:
-          - You want it to match the skeleton name inside `.blend` imports (optimized for Blender integration).
-     - Use `GeneralSkeleton` if:
-          - You need to target standard Godot `BoneMap` profiles.
+- **Skeleton Name**: `Skeleton3D` (matches `.blend` imports) or `GeneralSkeleton` (standard `BoneMap` profiles)
+
+> [!TIP]
+> For an easier rigging setup, check out **[vrm-control-rig](https://github.com/AzPepoze/vrm-control-rig)** — my Blender addon that auto-generates a control rig with IK, designed to work alongside this importer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Available in the Import dock when selecting a `.vrm` file (under **Advanced** mo
 | **Skeleton Name** | `Skeleton3D` | Skeleton node name. Use `Skeleton3D` for Blender workflows, `GeneralSkeleton` for standard `BoneMap` profiles |
 | **Remove End Bones** | `true` | Strips empty `_end` marker nodes from the skeleton |
 | **V1 Rotate 180** | `true` | Rotates VRM 1.0 root node 180° around Y |
-| **Clear Bone Rotation** | `true` | Sets all bone rest rotations to identity `(0,0,0,1)` — useful when the T-pose has unwanted rotation from retargeting |
+| **Clear Bone Rotation** | `true` | Sets all bone rest rotations to `(0,0,0,1)` (x,y,z,w) — useful when the T-pose has unwanted rotation from retargeting |
 
 ### Global Defaults
 
@@ -215,7 +215,7 @@ Set defaults in **Project Settings → VRM → Import** (enable **Advanced** tog
 | `vrm/import/skeleton_name` | `Skeleton3D` | Skeleton node name |
 | `vrm/import/remove_end_bones` | `true` | Remove end bones |
 | `vrm/import/v1_rotate_180` | `true` | Rotate VRM 1.0 root 180° on Y |
-| `vrm/import/clear_bone_rotation` | `true` | Clear bone rest rotations to identity |
+| `vrm/import/clear_bone_rotation` | `true` | Clear bone rest rotations to `(0,0,0,1)` (x,y,z,w) |
 
 In the import dialog, **Override Global Defaults** (disabled by default) reads from these project settings. Enable it to override settings for a specific file.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Available in the Import dock when selecting a `.vrm` file (under **Advanced** mo
 
 ### Global Defaults
 
-Set defaults in **Project Settings → General → VRM → Import** instead of configuring per-file:
+Set defaults in **Project Settings → VRM → Import** (enable **Advanced** toggle in the top-right to see them) instead of configuring per-file:
 
 | Setting | Default | Description |
 | ------- | :-----: | ----------- |
@@ -217,7 +217,7 @@ Set defaults in **Project Settings → General → VRM → Import** instead of c
 | `vrm/import/v1_rotate_180` | `true` | Rotate VRM 1.0 root 180° on Y |
 | `vrm/import/clear_bone_rotation` | `true` | Clear bone rest rotations to identity |
 
-In the import dialog, **Use Global Defaults** (enabled by default) reads from these project settings. Uncheck it to override settings for a specific file.
+In the import dialog, **Override Global Defaults** (disabled by default) reads from these project settings. Enable it to override settings for a specific file.
 
 ### Bone Rename Modes
 

--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -30,12 +30,16 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     var remove_end: bool = options.get(&"vrm/remove_end_bones", true) as bool
     var v1_rotate_180: bool = options.get(&"vrm/v1_rotate_180", true) as bool
 
+    var clear_bone_rotation: bool = options.get(&"vrm/clear_bone_rotation", true) as bool
     if not override_global:
         head_hiding = ProjectSettings.get_setting("vrm/import/head_hiding_method", head_hiding)
         bone_rename = ProjectSettings.get_setting("vrm/import/bone_rename", bone_rename)
         skeleton_name = ProjectSettings.get_setting("vrm/import/skeleton_name", skeleton_name)
         remove_end = ProjectSettings.get_setting("vrm/import/remove_end_bones", remove_end)
         v1_rotate_180 = ProjectSettings.get_setting("vrm/import/v1_rotate_180", v1_rotate_180)
+        clear_bone_rotation = ProjectSettings.get_setting(
+            "vrm/import/clear_bone_rotation", clear_bone_rotation
+        )
 
     state.set_additional_data(
         &"vrm/head_hiding_method", head_hiding as vrm_constants.HeadHidingSetting
@@ -55,10 +59,12 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     state.set_meta(&"vrm_remove_end_bones", true)
     state.set_additional_data(&"vrm/v1_rotate_180", v1_rotate_180)
     state.set_meta(&"vrm_v1_rotate_180", true)
+    state.set_additional_data(&"vrm/clear_bone_rotation", clear_bone_rotation)
+    state.set_meta(&"vrm_clear_bone_rotation", true)
     state.set_meta(&"vrm_bone_rename", bone_rename)
     state.set_meta(&"vrm_skeleton_name", skeleton_name)
     # HANDLE_BINARY_EMBED_AS_BASISU crashes on some files in 4.0 and 4.1
-    state.handle_binary_image = GLTFState.HANDLE_BINARY_EMBED_AS_UNCOMPRESSED # GLTFState.HANDLE_BINARY_EXTRACT_TEXTURES
+    state.handle_binary_image = GLTFState.HANDLE_BINARY_EMBED_AS_UNCOMPRESSED  # GLTFState.HANDLE_BINARY_EXTRACT_TEXTURES
     VRMLogger.info("import_vrm.gd", "_import_scene: importing %s" % path)
     var err = gltf.append_from_file(path, state, 8)
     if err != OK:

--- a/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
+++ b/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
@@ -6,11 +6,7 @@ signal foo
 
 func _get_import_options(path: String):
     if path.is_empty() or path.get_extension().to_lower() == "vrm":
-        add_import_option_advanced(
-            TYPE_BOOL,
-            "vrm/override_global_defaults",
-            false
-        )
+        add_import_option_advanced(TYPE_BOOL, "vrm/override_global_defaults", false)
         add_import_option_advanced(
             TYPE_INT,
             "vrm/head_hiding_method",
@@ -37,18 +33,7 @@ func _get_import_options(path: String):
             PROPERTY_HINT_ENUM,
             "None (Blender ready),Humanoid,Symmetrize VRoid Bone Names on X-Axis (Blender ready)"
         )
-        add_import_option_advanced(
-            TYPE_STRING,
-            "vrm/skeleton_name",
-            "Skeleton3D"
-        )
-        add_import_option_advanced(
-            TYPE_BOOL,
-            "vrm/remove_end_bones",
-            true
-        )
-        add_import_option_advanced(
-            TYPE_BOOL,
-            "vrm/v1_rotate_180",
-            true
-        )
+        add_import_option_advanced(TYPE_STRING, "vrm/skeleton_name", "Skeleton3D")
+        add_import_option_advanced(TYPE_BOOL, "vrm/remove_end_bones", true)
+        add_import_option_advanced(TYPE_BOOL, "vrm/v1_rotate_180", true)
+        add_import_option_advanced(TYPE_BOOL, "vrm/clear_bone_rotation", true)

--- a/addons/vrm/importer/common/vrm_skeleton_retargeting.gd
+++ b/addons/vrm/importer/common/vrm_skeleton_retargeting.gd
@@ -12,9 +12,8 @@ static func skeleton_rename(
     p_skeleton: Skeleton3D,
     p_bone_map: BoneMap,
     skeleton_name: String = "Skeleton3D",
-    
 ):
-    var bone_rename_mode: int = 1 # default to HUMANBONES (humanbones = 1)
+    var bone_rename_mode: int = 1  # default to HUMANBONES (humanbones = 1)
     if gstate.has_meta(&"vrm_bone_rename"):
         bone_rename_mode = gstate.get_meta(&"vrm_bone_rename") as int
     VRMBoneRenamer.rename_skeleton_bones(
@@ -27,7 +26,8 @@ static func skeleton_rotate(
     _p_base_scene: Node,
     src_skeleton: Skeleton3D,
     p_bone_map: BoneMap,
-    old_skeleton_global_rest: Array[Transform3D]
+    old_skeleton_global_rest: Array[Transform3D],
+    clear_bone_rotation: bool = false
 ) -> Array[Basis]:
     var is_renamed = true
     var profile = p_bone_map.profile
@@ -71,7 +71,9 @@ static func skeleton_rotate(
             if prof_bone_name != StringName():
                 prof_idx = profile.find_bone(prof_bone_name)
 
-            if prof_idx >= 0:
+            if clear_bone_rotation:
+                tgt_rot = Basis.IDENTITY
+            elif prof_idx >= 0:
                 tgt_rot = src_pg.inverse() * prof_skeleton.get_bone_global_rest(prof_idx).basis
 
         if src_skeleton.get_bone_parent(src_idx) >= 0:
@@ -107,7 +109,10 @@ static func perform_retarget(
     )
     skeleton_rename(gstate, root_node, skeleton, bone_map, skeleton_name)
     var old_skeleton_global_rest: Array[Transform3D]
-    var poses = skeleton_rotate(root_node, skeleton, bone_map, old_skeleton_global_rest)
+    var clear_bone_rotation: bool = gstate.get_additional_data(&"vrm/clear_bone_rotation")
+    var poses = skeleton_rotate(
+        root_node, skeleton, bone_map, old_skeleton_global_rest, clear_bone_rotation
+    )
     VRMMeshOrientation.apply_mesh_rotation(
         root_node, skeleton, old_skeleton_global_rest, global_transform_scale_local
     )

--- a/addons/vrm/importer/common/vrm_utils.gd
+++ b/addons/vrm/importer/common/vrm_utils.gd
@@ -50,10 +50,11 @@ static func skeleton_rotate(
     _p_base_scene: Node,
     src_skeleton: Skeleton3D,
     p_bone_map: BoneMap,
-    old_skeleton_global_rest: Array[Transform3D]
+    old_skeleton_global_rest: Array[Transform3D],
+    clear_bone_rotation: bool = false
 ) -> Array[Basis]:
     return VRMSkeletonRetargeting.skeleton_rotate(
-        _p_base_scene, src_skeleton, p_bone_map, old_skeleton_global_rest
+        _p_base_scene, src_skeleton, p_bone_map, old_skeleton_global_rest, clear_bone_rotation
     )
 
 
@@ -63,7 +64,6 @@ static func perform_retarget(
     skeleton: Skeleton3D,
     bone_map: BoneMap,
     skeleton_name: String = "Skeleton3D",
-    
 ) -> Array[Basis]:
     return VRMSkeletonRetargeting.perform_retarget(
         gstate, root_node, skeleton, bone_map, skeleton_name
@@ -119,19 +119,22 @@ static func apply_default_import_settings(gstate: GLTFState) -> void:
     # Set default additional_data values so get_additional_data()
     # doesn't trigger Godot 4.6 operator[] dict bug on missing keys.
     # These may be overridden later by the import dialog (import_vrm.gd).
-    
+
     var additional_data_defaults = {
-        &"vrm_head_hiding_method": [&"vrm/head_hiding_method", VRMConstants.HeadHidingSetting.ThirdPersonOnly],
+        &"vrm_head_hiding_method":
+        [&"vrm/head_hiding_method", VRMConstants.HeadHidingSetting.ThirdPersonOnly],
         &"vrm_first_person_layers": [&"vrm/first_person_layers", 2],
         &"vrm_third_person_layers": [&"vrm/third_person_layers", 4],
         &"vrm_remove_end_bones": [&"vrm/remove_end_bones", true],
         &"vrm_v1_rotate_180": [&"vrm/v1_rotate_180", true],
+        &"vrm_clear_bone_rotation": [&"vrm/clear_bone_rotation", true],
     }
-    
+
     for meta_key in additional_data_defaults:
         if not gstate.has_meta(meta_key):
-            gstate.set_additional_data(additional_data_defaults[meta_key][0], additional_data_defaults[meta_key][1])
-            
+            gstate.set_additional_data(
+                additional_data_defaults[meta_key][0], additional_data_defaults[meta_key][1]
+            )
+
     if not gstate.has_meta(&"vrm_skeleton_name"):
         gstate.set_meta(&"vrm_skeleton_name", "Skeleton3D")
-

--- a/addons/vrm/importer/v0/vrm_extension.gd
+++ b/addons/vrm/importer/v0/vrm_extension.gd
@@ -93,18 +93,18 @@ func _import_preflight(
     if extensions.has("VRMC_vrm"):
         # VRM 1.0 file. Do not parse as a VRM 0.0.
         return ERR_INVALID_DATA
-        
+
     # Godot 4.6 bug: get_additional_data uses [] internally, triggering
     # "Dictionary::operator[] used when there was no value for the given key".
     # Workaround: use GLTFState meta instead of additional_data for this sentinel.
     if gstate.has_meta(&"vrm_already_processed"):
         return ERR_SKIP
     gstate.set_meta(&"vrm_already_processed", true)
-    
+
     VRMLogger.debug("vrm_extension.gd", "_import_preflight: processing VRM 0.0 file")
-    
+
     vrm_utils.apply_default_import_settings(gstate)
-    
+
     var gltf_json_parsed: Dictionary = gstate.json
     var gltf_nodes = gltf_json_parsed["nodes"]
     if not _add_vrm_nodes_to_skin(gltf_json_parsed):
@@ -152,7 +152,6 @@ func _import_post(gstate: GLTFState, node: Node) -> Error:
     )
 
     var skeleton_name: String = gstate.get_meta(&"vrm_skeleton_name", "Skeleton3D") as String
-
 
     var pose_diffs: Array[Basis] = vrm_utils.perform_retarget(
         gstate, root_node, skeleton, humanBones, skeleton_name

--- a/addons/vrm/importer/v1/vrmc/vrmc_vrm.gd
+++ b/addons/vrm/importer/v1/vrmc/vrmc_vrm.gd
@@ -164,9 +164,9 @@ func _import_preflight(
 ) -> Error:
     if not extensions.has("VRMC_vrm"):
         return ERR_SKIP
-        
+
     vrm_utils.apply_default_import_settings(_state)
-    
+
     return OK
 
 

--- a/addons/vrm/plugin.gd
+++ b/addons/vrm/plugin.gd
@@ -37,29 +37,42 @@ var accept_dialog: AcceptDialog
 
 func register_import_settings() -> void:
     var import_settings := {
-        "vrm/import/head_hiding_method": {
+        "vrm/import/head_hiding_method":
+        {
             "type": TYPE_INT,
             "hint": PROPERTY_HINT_ENUM,
-            "hint_string": "ThirdPersonOnly,FirstPersonOnly,FirstWithShadow,Layers,LayersWithShadow,IgnoreHeadHiding",
+            "hint_string":
+            "ThirdPersonOnly,FirstPersonOnly,FirstWithShadow,Layers,LayersWithShadow,IgnoreHeadHiding",
             "default": 0,
         },
-        "vrm/import/bone_rename": {
+        "vrm/import/bone_rename":
+        {
             "type": TYPE_INT,
             "hint": PROPERTY_HINT_ENUM,
-            "hint_string": "None (Blender ready),Humanoid,Symmetrize VRoid Bone Names on X-Axis (Blender ready)",
+            "hint_string":
+            "None (Blender ready),Humanoid,Symmetrize VRoid Bone Names on X-Axis (Blender ready)",
             "default": 0,
         },
-        "vrm/import/skeleton_name": {
+        "vrm/import/skeleton_name":
+        {
             "type": TYPE_STRING,
             "hint": PROPERTY_HINT_NONE,
             "default": "Skeleton3D",
         },
-        "vrm/import/remove_end_bones": {
+        "vrm/import/remove_end_bones":
+        {
             "type": TYPE_BOOL,
             "hint": PROPERTY_HINT_NONE,
             "default": true,
         },
-        "vrm/import/v1_rotate_180": {
+        "vrm/import/v1_rotate_180":
+        {
+            "type": TYPE_BOOL,
+            "hint": PROPERTY_HINT_NONE,
+            "default": true,
+        },
+        "vrm/import/clear_bone_rotation":
+        {
             "type": TYPE_BOOL,
             "hint": PROPERTY_HINT_NONE,
             "default": true,

--- a/assets/vrm/AliciaSolid_vrm-0.51.vrm.import
+++ b/assets/vrm/AliciaSolid_vrm-0.51.vrm.import
@@ -51,3 +51,5 @@ vrm/only_if_head_hiding_uses_layers/third_person_layers=4
 vrm/bone_rename=0
 vrm/skeleton_name="Skeleton3D"
 vrm/remove_end_bones=true
+vrm/v1_rotate_180=true
+vrm/clear_bone_rotation=true

--- a/assets/vrm/AvatarSample_M.vrm.import
+++ b/assets/vrm/AvatarSample_M.vrm.import
@@ -45,3 +45,5 @@ vrm/only_if_head_hiding_uses_layers/third_person_layers=4
 vrm/bone_rename=1
 vrm/skeleton_name="Skeleton3D"
 vrm/remove_end_bones=true
+vrm/v1_rotate_180=true
+vrm/clear_bone_rotation=false

--- a/assets/vrm/Godette_vrm_v4.vrm.import
+++ b/assets/vrm/Godette_vrm_v4.vrm.import
@@ -45,3 +45,5 @@ vrm/only_if_head_hiding_uses_layers/third_person_layers=4
 vrm/bone_rename=0
 vrm/skeleton_name="Skeleton3D"
 vrm/remove_end_bones=true
+vrm/v1_rotate_180=true
+vrm/clear_bone_rotation=true

--- a/scenes/sample_scene.tscn
+++ b/scenes/sample_scene.tscn
@@ -1462,81 +1462,11 @@ radius = 0.06
 script = ExtResource("4_oiwk8")
 colliders = Array[ExtResource("5_s5ll8")]([SubResource("Resource_lgp22"), SubResource("Resource_froxa"), SubResource("Resource_0fesl")])
 
-[sub_resource type="Resource" id="Resource_biyun"]
-resource_name = "skirt_10_01"
+[sub_resource type="Resource" id="Resource_uw47o"]
+resource_name = "skirt_01_01"
 script = ExtResource("3_6idux")
 group = "skirt"
-joint_nodes = PackedStringArray("skirt_10_01", "skirt_10_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_8qwgd"]
-resource_name = "skirt_09_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_09_01", "skirt_09_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_52agq"]
-resource_name = "skirt_08_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_08_01", "skirt_08_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_0atml"]
-resource_name = "skirt_07_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_07_01", "skirt_07_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_g5knp"]
-resource_name = "skirt_06_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_06_01", "skirt_06_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_g7kw1"]
-resource_name = "skirt_05_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_05_01", "skirt_05_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_gi1y5"]
-resource_name = "skirt_04_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_04_01", "skirt_04_02", "")
-drag_force_scale = 0.8
-hit_radius_scale = 0.05
-gravity_scale = 0.05
-collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
-
-[sub_resource type="Resource" id="Resource_v3sw5"]
-resource_name = "skirt_03_01"
-script = ExtResource("3_6idux")
-group = "skirt"
-joint_nodes = PackedStringArray("skirt_03_01", "skirt_03_02", "")
+joint_nodes = PackedStringArray("skirt_01_01", "skirt_01_02", "")
 drag_force_scale = 0.8
 hit_radius_scale = 0.05
 gravity_scale = 0.05
@@ -1552,11 +1482,81 @@ hit_radius_scale = 0.05
 gravity_scale = 0.05
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
 
-[sub_resource type="Resource" id="Resource_uw47o"]
-resource_name = "skirt_01_01"
+[sub_resource type="Resource" id="Resource_v3sw5"]
+resource_name = "skirt_03_01"
 script = ExtResource("3_6idux")
 group = "skirt"
-joint_nodes = PackedStringArray("skirt_01_01", "skirt_01_02", "")
+joint_nodes = PackedStringArray("skirt_03_01", "skirt_03_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_gi1y5"]
+resource_name = "skirt_04_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_04_01", "skirt_04_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_g7kw1"]
+resource_name = "skirt_05_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_05_01", "skirt_05_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_g5knp"]
+resource_name = "skirt_06_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_06_01", "skirt_06_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_0atml"]
+resource_name = "skirt_07_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_07_01", "skirt_07_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_52agq"]
+resource_name = "skirt_08_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_08_01", "skirt_08_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_8qwgd"]
+resource_name = "skirt_09_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_09_01", "skirt_09_02", "")
+drag_force_scale = 0.8
+hit_radius_scale = 0.05
+gravity_scale = 0.05
+collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_2tdl1")])
+
+[sub_resource type="Resource" id="Resource_biyun"]
+resource_name = "skirt_10_01"
+script = ExtResource("3_6idux")
+group = "skirt"
+joint_nodes = PackedStringArray("skirt_10_01", "skirt_10_02", "")
 drag_force_scale = 0.8
 hit_radius_scale = 0.05
 gravity_scale = 0.05
@@ -3033,6 +3033,12 @@ gravity_scale = 0.0
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_r2jpi"), SubResource("Resource_ayclx")])
 center_bone = "Root"
 
+[sub_resource type="Resource" id="Resource_m3w5p"]
+script = ExtResource("6_l4noq")
+gizmo_spring_bone = true
+gizmo_show_body_collisions = true
+update_in_editor = true
+
 [sub_resource type="Resource" id="Resource_udu4s"]
 resource_name = "Bust · J_Sec_L_Bust1"
 script = ExtResource("3_6idux")
@@ -3779,7 +3785,7 @@ collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_bx8sr"), 
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_4wf7p"), SubResource("Resource_jw5ma"), SubResource("Resource_kvc02"), SubResource("Resource_kj872")])
 settings = SubResource("Resource_1hec4")
 
-[node name="VRMSpringBoneController" parent="Godette_vrm_v4" index="3" unique_id=2026018112]
+[node name="VRMSpringBoneController" parent="Godette_vrm_v4" index="3" unique_id=2036659166]
 update_in_editor = true
 gizmo_spring_bone = true
 spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_2383u"), SubResource("Resource_aj1uy"), SubResource("Resource_1xoni"), SubResource("Resource_b6c6s"), SubResource("Resource_ep3bh"), SubResource("Resource_i6o5b"), SubResource("Resource_7camr"), SubResource("Resource_0w46o")])
@@ -3897,17 +3903,17 @@ settings = SubResource("Resource_jv7sj")
 
 [node name="AliciaSolid_vrm-0_51" parent="." unique_id=1926456560 instance=ExtResource("7_8n6kf")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.029050946, 0, 0)
-spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_kws1l"), SubResource("Resource_22daj"), SubResource("Resource_gye3p"), SubResource("Resource_bj2ke"), SubResource("Resource_83rs6"), SubResource("Resource_d1qxi"), SubResource("Resource_diav4"), SubResource("Resource_s53rv"), SubResource("Resource_biyun"), SubResource("Resource_8qwgd"), SubResource("Resource_52agq"), SubResource("Resource_0atml"), SubResource("Resource_g5knp"), SubResource("Resource_g7kw1"), SubResource("Resource_gi1y5"), SubResource("Resource_v3sw5"), SubResource("Resource_wkhtb"), SubResource("Resource_uw47o")])
+spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_kws1l"), SubResource("Resource_22daj"), SubResource("Resource_gye3p"), SubResource("Resource_bj2ke"), SubResource("Resource_83rs6"), SubResource("Resource_d1qxi"), SubResource("Resource_diav4"), SubResource("Resource_s53rv"), SubResource("Resource_uw47o"), SubResource("Resource_wkhtb"), SubResource("Resource_v3sw5"), SubResource("Resource_gi1y5"), SubResource("Resource_g7kw1"), SubResource("Resource_g5knp"), SubResource("Resource_0atml"), SubResource("Resource_52agq"), SubResource("Resource_8qwgd"), SubResource("Resource_biyun")])
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_itdgx"), SubResource("Resource_2tdl1")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_xol2m"), SubResource("Resource_tcpeh"), SubResource("Resource_4tx60"), SubResource("Resource_u3be1"), SubResource("Resource_jw4kh"), SubResource("Resource_s6en0"), SubResource("Resource_lgp22"), SubResource("Resource_froxa"), SubResource("Resource_0fesl"), SubResource("Resource_jstv3"), SubResource("Resource_wlhup"), SubResource("Resource_c68qo"), SubResource("Resource_1mx4j"), SubResource("Resource_lx0lc")])
 settings = SubResource("Resource_xmba4")
 
-[node name="VRMSpringBoneController" parent="AliciaSolid_vrm-0_51" index="4" unique_id=830548356]
+[node name="VRMSpringBoneController" parent="AliciaSolid_vrm-0_51" index="4" unique_id=828258667]
 update_in_editor = true
 gizmo_spring_bone = true
 gizmo_display_mode = 1
 gizmo_show_body_collisions = true
-spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_kws1l"), SubResource("Resource_22daj"), SubResource("Resource_gye3p"), SubResource("Resource_bj2ke"), SubResource("Resource_83rs6"), SubResource("Resource_d1qxi"), SubResource("Resource_diav4"), SubResource("Resource_s53rv"), SubResource("Resource_uw47o"), SubResource("Resource_wkhtb"), SubResource("Resource_v3sw5"), SubResource("Resource_gi1y5"), SubResource("Resource_g7kw1"), SubResource("Resource_g5knp"), SubResource("Resource_0atml"), SubResource("Resource_52agq"), SubResource("Resource_8qwgd"), SubResource("Resource_biyun")])
+spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_kws1l"), SubResource("Resource_22daj"), SubResource("Resource_gye3p"), SubResource("Resource_bj2ke"), SubResource("Resource_83rs6"), SubResource("Resource_d1qxi"), SubResource("Resource_diav4"), SubResource("Resource_s53rv"), SubResource("Resource_biyun"), SubResource("Resource_8qwgd"), SubResource("Resource_52agq"), SubResource("Resource_0atml"), SubResource("Resource_g5knp"), SubResource("Resource_g7kw1"), SubResource("Resource_gi1y5"), SubResource("Resource_v3sw5"), SubResource("Resource_wkhtb"), SubResource("Resource_uw47o")])
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_rn3ps"), SubResource("Resource_l5g6t"), SubResource("Resource_fxgvk"), SubResource("Resource_6nogv"), SubResource("Resource_itdgx"), SubResource("Resource_2tdl1")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_xol2m"), SubResource("Resource_tcpeh"), SubResource("Resource_4tx60"), SubResource("Resource_u3be1"), SubResource("Resource_jw4kh"), SubResource("Resource_s6en0"), SubResource("Resource_lgp22"), SubResource("Resource_froxa"), SubResource("Resource_0fesl"), SubResource("Resource_jstv3"), SubResource("Resource_wlhup"), SubResource("Resource_c68qo"), SubResource("Resource_1mx4j"), SubResource("Resource_lx0lc")])
 
@@ -3919,12 +3925,16 @@ collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_7we05"),
 settings = SubResource("Resource_f2ryh")
 
 [node name="AvatarSample_M3" parent="." unique_id=2030425638 instance=ExtResource("9_fenef")]
-transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, -4.2292023, 0, -0.022487521)
+transform = Transform3D(-0.99999994, 0, -1.5099579e-07, 0, 1, 0, 1.5099579e-07, 0, -0.99999994, -4.2292023, 0, -0.022487521)
 spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_rhl6r"), SubResource("Resource_aaotc"), SubResource("Resource_c31q5"), SubResource("Resource_0q6v6"), SubResource("Resource_s31aw"), SubResource("Resource_pobqr"), SubResource("Resource_6524d"), SubResource("Resource_yyo5r"), SubResource("Resource_mii8t"), SubResource("Resource_pk4u7"), SubResource("Resource_uf57b"), SubResource("Resource_b6kpx"), SubResource("Resource_r236j"), SubResource("Resource_qrmg2"), SubResource("Resource_d4yp7"), SubResource("Resource_yrlmx"), SubResource("Resource_2l0kq"), SubResource("Resource_n6sks"), SubResource("Resource_ylinx"), SubResource("Resource_xildi"), SubResource("Resource_52peo"), SubResource("Resource_j5xj2"), SubResource("Resource_qhe8o"), SubResource("Resource_upm6c"), SubResource("Resource_6d50q"), SubResource("Resource_62xdq"), SubResource("Resource_n1kvk"), SubResource("Resource_v1amv"), SubResource("Resource_g21kd"), SubResource("Resource_0uyim"), SubResource("Resource_xjfv6"), SubResource("Resource_lk0rq"), SubResource("Resource_epokm"), SubResource("Resource_s526v"), SubResource("Resource_h1v0t"), SubResource("Resource_0prqm")])
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_jlfre"), SubResource("Resource_w8xd1"), SubResource("Resource_ugiwr"), SubResource("Resource_d647r"), SubResource("Resource_tx7t6"), SubResource("Resource_086la"), SubResource("Resource_oo4lr"), SubResource("Resource_m60rq"), SubResource("Resource_cg12d"), SubResource("Resource_vidtu"), SubResource("Resource_r2jpi"), SubResource("Resource_ayclx")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_5bscg"), SubResource("Resource_ghilo"), SubResource("Resource_5uhi0"), SubResource("Resource_f7773"), SubResource("Resource_7dnc8"), SubResource("Resource_c23x0"), SubResource("Resource_gj48a"), SubResource("Resource_3y8yo"), SubResource("Resource_ycfif"), SubResource("Resource_0qutb"), SubResource("Resource_oldjd"), SubResource("Resource_fjnkh"), SubResource("Resource_cqidi"), SubResource("Resource_dnh7e"), SubResource("Resource_30a3o"), SubResource("Resource_5kup4"), SubResource("Resource_r3ym3"), SubResource("Resource_6m2su"), SubResource("Resource_6uf6e"), SubResource("Resource_oyrga"), SubResource("Resource_1wsl6"), SubResource("Resource_qdwxi"), SubResource("Resource_7wf7r"), SubResource("Resource_fuwim"), SubResource("Resource_h4v6s"), SubResource("Resource_743hs"), SubResource("Resource_a5qa1"), SubResource("Resource_ju7xn")])
+settings = SubResource("Resource_m3w5p")
 
-[node name="VRMSpringBoneController" parent="AvatarSample_M3" index="2" unique_id=1579905873]
+[node name="VRMSpringBoneController" parent="AvatarSample_M3" index="2" unique_id=1196510792]
+update_in_editor = true
+gizmo_spring_bone = true
+gizmo_show_body_collisions = true
 spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_rhl6r"), SubResource("Resource_aaotc"), SubResource("Resource_b6kpx"), SubResource("Resource_uf57b"), SubResource("Resource_pk4u7"), SubResource("Resource_mii8t"), SubResource("Resource_yyo5r"), SubResource("Resource_6524d"), SubResource("Resource_pobqr"), SubResource("Resource_s31aw"), SubResource("Resource_0q6v6"), SubResource("Resource_c31q5"), SubResource("Resource_6d50q"), SubResource("Resource_62xdq"), SubResource("Resource_n1kvk"), SubResource("Resource_v1amv"), SubResource("Resource_g21kd"), SubResource("Resource_0uyim"), SubResource("Resource_xjfv6"), SubResource("Resource_lk0rq"), SubResource("Resource_epokm"), SubResource("Resource_s526v"), SubResource("Resource_h1v0t"), SubResource("Resource_0prqm"), SubResource("Resource_upm6c"), SubResource("Resource_qhe8o"), SubResource("Resource_j5xj2"), SubResource("Resource_52peo"), SubResource("Resource_xildi"), SubResource("Resource_ylinx"), SubResource("Resource_n6sks"), SubResource("Resource_2l0kq"), SubResource("Resource_yrlmx"), SubResource("Resource_d4yp7"), SubResource("Resource_qrmg2"), SubResource("Resource_r236j")])
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_jlfre"), SubResource("Resource_w8xd1"), SubResource("Resource_ugiwr"), SubResource("Resource_d647r"), SubResource("Resource_tx7t6"), SubResource("Resource_086la"), SubResource("Resource_oo4lr"), SubResource("Resource_m60rq"), SubResource("Resource_cg12d"), SubResource("Resource_vidtu"), SubResource("Resource_r2jpi"), SubResource("Resource_ayclx")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_5bscg"), SubResource("Resource_ghilo"), SubResource("Resource_5uhi0"), SubResource("Resource_f7773"), SubResource("Resource_7dnc8"), SubResource("Resource_c23x0"), SubResource("Resource_gj48a"), SubResource("Resource_3y8yo"), SubResource("Resource_ycfif"), SubResource("Resource_0qutb"), SubResource("Resource_oldjd"), SubResource("Resource_fjnkh"), SubResource("Resource_cqidi"), SubResource("Resource_dnh7e"), SubResource("Resource_30a3o"), SubResource("Resource_5kup4"), SubResource("Resource_r3ym3"), SubResource("Resource_6m2su"), SubResource("Resource_6uf6e"), SubResource("Resource_oyrga"), SubResource("Resource_1wsl6"), SubResource("Resource_qdwxi"), SubResource("Resource_7wf7r"), SubResource("Resource_fuwim"), SubResource("Resource_h4v6s"), SubResource("Resource_743hs"), SubResource("Resource_a5qa1"), SubResource("Resource_ju7xn")])
@@ -3935,7 +3945,7 @@ spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_udu4s"), Sub
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_aerdg"), SubResource("Resource_2wfwu"), SubResource("Resource_dnh0r"), SubResource("Resource_oiwk8"), SubResource("Resource_e351d"), SubResource("Resource_8q5w4"), SubResource("Resource_vnsw2"), SubResource("Resource_x320b"), SubResource("Resource_mgbp4"), SubResource("Resource_15te1"), SubResource("Resource_pjb2h"), SubResource("Resource_mmjl1")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_x5xjk"), SubResource("Resource_buy0c"), SubResource("Resource_jve83"), SubResource("Resource_ku8b3"), SubResource("Resource_n5ok6"), SubResource("Resource_6idux"), SubResource("Resource_s5ll8"), SubResource("Resource_l4noq"), SubResource("Resource_8n6kf"), SubResource("Resource_4dbp5"), SubResource("Resource_f02yu"), SubResource("Resource_g2i3f"), SubResource("Resource_c4gr1"), SubResource("Resource_ab7g6"), SubResource("Resource_fenef"), SubResource("Resource_6yaw1"), SubResource("Resource_o6mf3"), SubResource("Resource_a5m24"), SubResource("Resource_l7tra"), SubResource("Resource_y2ote"), SubResource("Resource_t5r68"), SubResource("Resource_uhbgg"), SubResource("Resource_vlnpk"), SubResource("Resource_tiibn"), SubResource("Resource_68n76"), SubResource("Resource_eeqqf"), SubResource("Resource_1qp2j"), SubResource("Resource_ng88m")])
 
-[node name="VRMSpringBoneController" parent="AvatarSample_M4" index="2" unique_id=1579905873]
+[node name="VRMSpringBoneController" parent="AvatarSample_M4" index="2" unique_id=1196510792]
 spring_bones = Array[ExtResource("3_6idux")]([SubResource("Resource_udu4s"), SubResource("Resource_kg8jk"), SubResource("Resource_64kpk"), SubResource("Resource_s074h"), SubResource("Resource_a1u3t"), SubResource("Resource_a1ot3"), SubResource("Resource_islx4"), SubResource("Resource_qmdem"), SubResource("Resource_dvu4t"), SubResource("Resource_1yqvi"), SubResource("Resource_2dldi"), SubResource("Resource_q61v5"), SubResource("Resource_8g4yy"), SubResource("Resource_tb13f"), SubResource("Resource_ifxv4"), SubResource("Resource_6fqwu"), SubResource("Resource_saw1w"), SubResource("Resource_iso6r"), SubResource("Resource_nm5it"), SubResource("Resource_xisw7"), SubResource("Resource_bf0kh"), SubResource("Resource_k4ptb"), SubResource("Resource_dwn1w"), SubResource("Resource_7r2mc"), SubResource("Resource_md0hw"), SubResource("Resource_sb6vt"), SubResource("Resource_q6ldh"), SubResource("Resource_47w36"), SubResource("Resource_25fmc"), SubResource("Resource_pvs1f"), SubResource("Resource_sbbjb"), SubResource("Resource_w4wg4"), SubResource("Resource_i5dam"), SubResource("Resource_0clta"), SubResource("Resource_cprsw"), SubResource("Resource_uul3h")])
 collider_groups = Array[ExtResource("4_oiwk8")]([SubResource("Resource_aerdg"), SubResource("Resource_2wfwu"), SubResource("Resource_dnh0r"), SubResource("Resource_oiwk8"), SubResource("Resource_e351d"), SubResource("Resource_8q5w4"), SubResource("Resource_vnsw2"), SubResource("Resource_x320b"), SubResource("Resource_mgbp4"), SubResource("Resource_15te1"), SubResource("Resource_pjb2h"), SubResource("Resource_mmjl1")])
 collider_library = Array[ExtResource("5_s5ll8")]([SubResource("Resource_x5xjk"), SubResource("Resource_buy0c"), SubResource("Resource_jve83"), SubResource("Resource_ku8b3"), SubResource("Resource_n5ok6"), SubResource("Resource_6idux"), SubResource("Resource_s5ll8"), SubResource("Resource_l4noq"), SubResource("Resource_8n6kf"), SubResource("Resource_4dbp5"), SubResource("Resource_f02yu"), SubResource("Resource_g2i3f"), SubResource("Resource_c4gr1"), SubResource("Resource_ab7g6"), SubResource("Resource_fenef"), SubResource("Resource_6yaw1"), SubResource("Resource_o6mf3"), SubResource("Resource_a5m24"), SubResource("Resource_l7tra"), SubResource("Resource_y2ote"), SubResource("Resource_t5r68"), SubResource("Resource_uhbgg"), SubResource("Resource_vlnpk"), SubResource("Resource_tiibn"), SubResource("Resource_68n76"), SubResource("Resource_eeqqf"), SubResource("Resource_1qp2j"), SubResource("Resource_ng88m")])

--- a/tests/test_vrm1_import.gd
+++ b/tests/test_vrm1_import.gd
@@ -512,7 +512,7 @@ func test_vrm1_end_bone_nodes_removed():
         0,
         (
             "Skeleton should have zero children named '*_end*' after cleanup, "
-            +"but found %d: %s" % [end_bone_nodes.size(), str(end_bone_nodes)]
+            + "but found %d: %s" % [end_bone_nodes.size(), str(end_bone_nodes)]
         )
     )
     test_completed = true
@@ -581,7 +581,10 @@ func test_vrm1_import_without_rotation():
             var y_rot = scene.rotation_degrees.y
             assert_true(
                 abs(y_rot) < 0.1,
-                "VRM instance root node must NOT be rotated by 180 degrees around Y (got %f)" % y_rot
+                (
+                    "VRM instance root node must NOT be rotated by 180 degrees around Y (got %f)"
+                    % y_rot
+                )
             )
         if scene:
             scene.free()
@@ -618,7 +621,7 @@ func test_vrm1_import_none_bone_rename():
     state.set_additional_data(&"vrm/remove_end_bones", true)
     state.set_meta(&"vrm_remove_end_bones", true)
     state.set_meta(&"vrm_skeleton_name", "Skeleton3D")
-    state.set_meta(&"vrm_bone_rename", 0) # BoneRenameMode.NONE
+    state.set_meta(&"vrm_bone_rename", 0)  # BoneRenameMode.NONE
 
     var err = gltf.append_from_file(VRM_FILE, state, 8)
     assert_eq(err, OK, "Import under NONE mode must succeed")
@@ -672,7 +675,7 @@ func test_vrm1_import_symmetrize_bone_rename():
     state.set_additional_data(&"vrm/remove_end_bones", true)
     state.set_meta(&"vrm_remove_end_bones", true)
     state.set_meta(&"vrm_skeleton_name", "Skeleton3D")
-    state.set_meta(&"vrm_bone_rename", 2) # BoneRenameMode.SYMMETRIZE_VROID
+    state.set_meta(&"vrm_bone_rename", 2)  # BoneRenameMode.SYMMETRIZE_VROID
 
     var err = gltf.append_from_file(VRM_FILE, state, 8)
     assert_eq(err, OK, "Import under SYMMETRIZE mode must succeed")
@@ -741,6 +744,70 @@ func test_vrm1_import_custom_skeleton_name():
                 )
                 # Verify it's still a valid skeleton with bones
                 assert_ge(skel.find_bone("Hips"), 0, "Hips bone must exist under custom name")
+            scene.free()
+
+    for ext in extensions:
+        GLTFDocument.unregister_gltf_document_extension(ext)
+    test_completed = true
+
+
+func test_vrm1_import_clear_bone_rotation():
+    """Verify that clear_bone_rotation=true sets all bone rest rotations to identity."""
+    var gltf = GLTFDocument.new()
+    var extensions = [
+        VRMC_NODE_CONSTRAINT.new(),
+        VRMC_SPRING_BONE.new(),
+        VRMC_MTOON.new(),
+        VRMC_HDR_EMISSIVE.new(),
+        VRMC_VRM.new(),
+        VRMC_VRM_ANIMATION.new(),
+    ]
+
+    for ext in extensions:
+        GLTFDocument.register_gltf_document_extension(ext, true)
+
+    var state := GLTFState.new()
+    const VRMConstants = preload("res://addons/vrm/core/vrm_constants.gd")
+    state.set_additional_data(
+        &"vrm/head_hiding_method", VRMConstants.HeadHidingSetting.ThirdPersonOnly
+    )
+    state.set_meta(&"vrm_head_hiding_method", true)
+    state.set_additional_data(&"vrm/first_person_layers", 2)
+    state.set_meta(&"vrm_first_person_layers", true)
+    state.set_additional_data(&"vrm/third_person_layers", 4)
+    state.set_meta(&"vrm_third_person_layers", true)
+    state.set_additional_data(&"vrm/remove_end_bones", true)
+    state.set_meta(&"vrm_remove_end_bones", true)
+    state.set_meta(&"vrm_skeleton_name", "Skeleton3D")
+    state.set_additional_data(&"vrm/v1_rotate_180", false)
+    state.set_meta(&"vrm_v1_rotate_180", true)
+    state.set_additional_data(&"vrm/clear_bone_rotation", true)
+    state.set_meta(&"vrm_clear_bone_rotation", true)
+
+    var err = gltf.append_from_file(VRM_FILE, state, 8)
+    assert_eq(err, OK, "Import with clear_bone_rotation=true must succeed")
+    if err == OK:
+        var scene = gltf.generate_scene(state)
+        assert_not_null(scene, "Generated scene must not be null")
+        if scene:
+            var skeleton = _find_skeleton(scene)
+            assert_not_null(skeleton, "Skeleton must exist in imported scene")
+            if skeleton:
+                var non_identity_bones: Array[String] = []
+                for i in range(skeleton.get_bone_count()):
+                    var rest: Transform3D = skeleton.get_bone_rest(i)
+                    if not rest.basis.is_equal_approx(Basis.IDENTITY):
+                        non_identity_bones.append(
+                            "%s (idx %d): %s" % [skeleton.get_bone_name(i), i, str(rest.basis)]
+                        )
+                assert_eq(
+                    non_identity_bones.size(),
+                    0,
+                    (
+                        "All bone rest rotations must be identity, but %d bones are not:\n%s"
+                        % [non_identity_bones.size(), "\n".join(non_identity_bones)]
+                    )
+                )
             scene.free()
 
     for ext in extensions:

--- a/tests/test_vrm_import.gd
+++ b/tests/test_vrm_import.gd
@@ -448,9 +448,7 @@ func test_v0_custom_skeleton_name():
     if skeletons.size() > 0:
         var skel: Skeleton3D = skeletons[0]
         assert_eq(
-            skel.name,
-            "MyV0Skeleton",
-            "Skeleton must be named 'MyV0Skeleton', got '%s'" % skel.name
+            skel.name, "MyV0Skeleton", "Skeleton must be named 'MyV0Skeleton', got '%s'" % skel.name
         )
         # Verify it's still a valid skeleton with bones
         assert_ge(skel.find_bone("Hips"), 0, "Hips bone must exist under custom name")


### PR DESCRIPTION
## Changes

- **New import option: `vrm/clear_bone_rotation`** (default: `true`) — sets all bone rest rotations to `(0,0,0,1)` (x,y,z,w) identity quaternion, fixing unwanted T-pose rotation from retargeting
- Updated README with all import options documented as tables
- Added link to [vrm-control-rig](https://github.com/AzPepoze/vrm-control-rig) Blender addon

🤖 Generated with [Claude Code](https://claude.com/claude-code)