### PR TITLE
feat: Blender Leg Fix import option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ data_*/
 
 # Local secrets for act
 .secrets
+
+*.blend1

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Available in the Import dock when selecting a `.vrm` file (under **Advanced** mo
 | **Skeleton Name** | `Skeleton3D` | Skeleton node name. Use `Skeleton3D` for Blender workflows, `GeneralSkeleton` for standard `BoneMap` profiles |
 | **Remove End Bones** | `true` | Strips empty `_end` marker nodes from the skeleton |
 | **V1 Rotate 180** | `true` | Rotates VRM 1.0 root node 180° around Y |
-| **Clear Bone Rotation** | `true` | Sets all bone rest rotations to `(0,0,0,1)` (x,y,z,w) — useful when the T-pose has unwanted rotation from retargeting |
+| **Clear Bone Rotation** | `true` | Sets non-leg bone rest rotations to `(0,0,0,1)` (x,y,z,w). Leg bones keep their profile target rotation |
+| **Blender Leg Fix** | `true` | Fixes leg bone orientation for Blender-exported VRM animations. Applies 180° Y rotation to lower legs and 180° X+Z to feet. Requires **Clear Bone Rotation** to be enabled |
 
 ### Global Defaults
 
@@ -215,7 +216,8 @@ Set defaults in **Project Settings → VRM → Import** (enable **Advanced** tog
 | `vrm/import/skeleton_name` | `Skeleton3D` | Skeleton node name |
 | `vrm/import/remove_end_bones` | `true` | Remove end bones |
 | `vrm/import/v1_rotate_180` | `true` | Rotate VRM 1.0 root 180° on Y |
-| `vrm/import/clear_bone_rotation` | `true` | Clear bone rest rotations to `(0,0,0,1)` (x,y,z,w) |
+| `vrm/import/clear_bone_rotation` | `true` | Clear non-leg bone rest rotations to `(0,0,0,1)` (x,y,z,w) |
+| `vrm/import/blender_leg_fix` | `true` | Fix lower leg and foot bone orientation for Blender VRM animations |
 
 In the import dialog, **Override Global Defaults** (disabled by default) reads from these project settings. Enable it to override settings for a specific file.
 

--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -31,6 +31,7 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     var v1_rotate_180: bool = options.get(&"vrm/v1_rotate_180", true) as bool
 
     var clear_bone_rotation: bool = options.get(&"vrm/clear_bone_rotation", true) as bool
+    var blender_leg_fix: bool = options.get(&"vrm/blender_leg_fix", true) as bool
     if not override_global:
         head_hiding = ProjectSettings.get_setting("vrm/import/head_hiding_method", head_hiding)
         bone_rename = ProjectSettings.get_setting("vrm/import/bone_rename", bone_rename)
@@ -39,6 +40,9 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
         v1_rotate_180 = ProjectSettings.get_setting("vrm/import/v1_rotate_180", v1_rotate_180)
         clear_bone_rotation = ProjectSettings.get_setting(
             "vrm/import/clear_bone_rotation", clear_bone_rotation
+        )
+        blender_leg_fix = ProjectSettings.get_setting(
+            "vrm/import/blender_leg_fix", blender_leg_fix
         )
 
     state.set_additional_data(
@@ -61,6 +65,8 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
     state.set_meta(&"vrm_v1_rotate_180", true)
     state.set_additional_data(&"vrm/clear_bone_rotation", clear_bone_rotation)
     state.set_meta(&"vrm_clear_bone_rotation", true)
+    state.set_additional_data(&"vrm/blender_leg_fix", blender_leg_fix)
+    state.set_meta(&"vrm_blender_leg_fix", true)
     state.set_meta(&"vrm_bone_rename", bone_rename)
     state.set_meta(&"vrm_skeleton_name", skeleton_name)
     # HANDLE_BINARY_EMBED_AS_BASISU crashes on some files in 4.0 and 4.1

--- a/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
+++ b/addons/vrm/importer/common/vrm_options_post_import_plugin.gd
@@ -37,3 +37,4 @@ func _get_import_options(path: String):
         add_import_option_advanced(TYPE_BOOL, "vrm/remove_end_bones", true)
         add_import_option_advanced(TYPE_BOOL, "vrm/v1_rotate_180", true)
         add_import_option_advanced(TYPE_BOOL, "vrm/clear_bone_rotation", true)
+        add_import_option_advanced(TYPE_BOOL, "vrm/blender_leg_fix", true)

--- a/addons/vrm/importer/common/vrm_skeleton_retargeting.gd
+++ b/addons/vrm/importer/common/vrm_skeleton_retargeting.gd
@@ -27,7 +27,8 @@ static func skeleton_rotate(
     src_skeleton: Skeleton3D,
     p_bone_map: BoneMap,
     old_skeleton_global_rest: Array[Transform3D],
-    clear_bone_rotation: bool = false
+    clear_bone_rotation: bool = false,
+    blender_leg_fix: bool = false
 ) -> Array[Basis]:
     var is_renamed = true
     var profile = p_bone_map.profile
@@ -58,9 +59,9 @@ static func skeleton_rotate(
 
         var tgt_rot: Basis
         var src_bone_name: StringName = StringName(src_skeleton.get_bone_name(src_idx))
+        var src_parent_idx: int = src_skeleton.get_bone_parent(src_idx)
         if src_bone_name != StringName():
             var src_pg: Basis
-            var src_parent_idx: int = src_skeleton.get_bone_parent(src_idx)
             if src_parent_idx >= 0:
                 src_pg = src_skeleton.get_bone_global_rest(src_parent_idx).basis
             var prof_bone_name: StringName = p_bone_map.find_profile_bone_name(src_bone_name)
@@ -71,10 +72,33 @@ static func skeleton_rotate(
             if prof_bone_name != StringName():
                 prof_idx = profile.find_bone(prof_bone_name)
 
-            if clear_bone_rotation:
+            # Resolve canonical profile bone name (works with any naming scheme via BoneMap)
+            var prof_bone_name_for_check := prof_bone_name
+            if prof_bone_name_for_check == StringName() and prof_idx >= 0:
+                prof_bone_name_for_check = profile.get_bone_name(prof_idx)
+
+            var is_leg_bone := prof_bone_name_for_check in [
+                "LeftUpperLeg", "RightUpperLeg",
+                "LeftLowerLeg", "RightLowerLeg",
+                "LeftFoot", "RightFoot",
+                "LeftToes", "RightToes",
+            ]
+            if clear_bone_rotation and not is_leg_bone:
                 tgt_rot = Basis.IDENTITY
             elif prof_idx >= 0:
                 tgt_rot = src_pg.inverse() * prof_skeleton.get_bone_global_rest(prof_idx).basis
+
+            # Bone-specific rotation overrides for Blender-exported VRM animations
+            # Uses profile bone names so it works regardless of skeleton naming scheme
+            if blender_leg_fix:
+                var leg_overrides := {
+                    "LeftLowerLeg": Basis(Vector3(0, 1, 0), PI),
+                    "RightLowerLeg": Basis(Vector3(0, 1, 0), PI),
+                    "LeftFoot": Basis(Vector3(1, 0, 0), PI) * Basis(Vector3(0, 0, 1), PI),
+                    "RightFoot": Basis(Vector3(1, 0, 0), PI) * Basis(Vector3(0, 0, 1), PI),
+                }
+                if prof_bone_name_for_check in leg_overrides:
+                    tgt_rot = tgt_rot * leg_overrides[prof_bone_name_for_check]
 
         if src_skeleton.get_bone_parent(src_idx) >= 0:
             diffs[src_idx] = (
@@ -93,6 +117,7 @@ static func skeleton_rotate(
             src_idx, Transform3D(tgt_rot, diff * src_skeleton.get_bone_rest(src_idx).origin)
         )
 
+
     prof_skeleton.queue_free()
     return diffs
 
@@ -110,8 +135,9 @@ static func perform_retarget(
     skeleton_rename(gstate, root_node, skeleton, bone_map, skeleton_name)
     var old_skeleton_global_rest: Array[Transform3D]
     var clear_bone_rotation: bool = gstate.get_additional_data(&"vrm/clear_bone_rotation")
+    var blender_leg_fix: bool = gstate.get_additional_data(&"vrm/blender_leg_fix")
     var poses = skeleton_rotate(
-        root_node, skeleton, bone_map, old_skeleton_global_rest, clear_bone_rotation
+        root_node, skeleton, bone_map, old_skeleton_global_rest, clear_bone_rotation, blender_leg_fix
     )
     VRMMeshOrientation.apply_mesh_rotation(
         root_node, skeleton, old_skeleton_global_rest, global_transform_scale_local

--- a/addons/vrm/importer/common/vrm_utils.gd
+++ b/addons/vrm/importer/common/vrm_utils.gd
@@ -51,10 +51,11 @@ static func skeleton_rotate(
     src_skeleton: Skeleton3D,
     p_bone_map: BoneMap,
     old_skeleton_global_rest: Array[Transform3D],
-    clear_bone_rotation: bool = false
+    clear_bone_rotation: bool = false,
+    blender_leg_fix: bool = false
 ) -> Array[Basis]:
     return VRMSkeletonRetargeting.skeleton_rotate(
-        _p_base_scene, src_skeleton, p_bone_map, old_skeleton_global_rest, clear_bone_rotation
+        _p_base_scene, src_skeleton, p_bone_map, old_skeleton_global_rest, clear_bone_rotation, blender_leg_fix
     )
 
 
@@ -128,6 +129,7 @@ static func apply_default_import_settings(gstate: GLTFState) -> void:
         &"vrm_remove_end_bones": [&"vrm/remove_end_bones", true],
         &"vrm_v1_rotate_180": [&"vrm/v1_rotate_180", true],
         &"vrm_clear_bone_rotation": [&"vrm/clear_bone_rotation", true],
+        &"vrm_blender_leg_fix": [&"vrm/blender_leg_fix", true],
     }
 
     for meta_key in additional_data_defaults:

--- a/addons/vrm/plugin.gd
+++ b/addons/vrm/plugin.gd
@@ -77,6 +77,12 @@ func register_import_settings() -> void:
             "hint": PROPERTY_HINT_NONE,
             "default": true,
         },
+        "vrm/import/blender_leg_fix":
+        {
+            "type": TYPE_BOOL,
+            "hint": PROPERTY_HINT_NONE,
+            "default": true,
+        },
     }
     for setting_name in import_settings:
         if not ProjectSettings.has_setting(setting_name):

--- a/tests/test_vrm1_import.gd
+++ b/tests/test_vrm1_import.gd
@@ -752,7 +752,7 @@ func test_vrm1_import_custom_skeleton_name():
 
 
 func test_vrm1_import_clear_bone_rotation():
-    """Verify that clear_bone_rotation=true sets all bone rest rotations to identity."""
+    """Verify that clear_bone_rotation=true sets non-leg bone rest rotations to identity."""
     var gltf = GLTFDocument.new()
     var extensions = [
         VRMC_NODE_CONSTRAINT.new(),
@@ -794,17 +794,26 @@ func test_vrm1_import_clear_bone_rotation():
             assert_not_null(skeleton, "Skeleton must exist in imported scene")
             if skeleton:
                 var non_identity_bones: Array[String] = []
+                var leg_exceptions := [
+                    "LeftUpperLeg", "RightUpperLeg",
+                    "LeftLowerLeg", "RightLowerLeg",
+                    "LeftFoot", "RightFoot",
+                    "LeftToes", "RightToes",
+                ]
                 for i in range(skeleton.get_bone_count()):
+                    var bone_name: String = skeleton.get_bone_name(i)
+                    if bone_name in leg_exceptions:
+                        continue
                     var rest: Transform3D = skeleton.get_bone_rest(i)
                     if not rest.basis.is_equal_approx(Basis.IDENTITY):
                         non_identity_bones.append(
-                            "%s (idx %d): %s" % [skeleton.get_bone_name(i), i, str(rest.basis)]
+                            "%s (idx %d): %s" % [bone_name, i, str(rest.basis)]
                         )
                 assert_eq(
                     non_identity_bones.size(),
                     0,
                     (
-                        "All bone rest rotations must be identity, but %d bones are not:\n%s"
+                        "All non-leg bone rest rotations must be identity, but %d bones are not:\n%s"
                         % [non_identity_bones.size(), "\n".join(non_identity_bones)]
                     )
                 )


### PR DESCRIPTION
## What

Adds `vrm/import/blender_leg_fix` import option (default `true`) to fix leg bone orientation for Blender-exported VRM animations.

## Changes

- Leg bones (upper/lower/foot/toes) keep profile target rotation when **Clear Bone Rotation** is enabled
- Lower leg gets 180° Y rotation override, foot gets 180° X + 180° Z overrides
- Uses BoneMap profile bone names — works with any skeleton naming scheme (J_Bip_*, LeftUpLeg, thigh.l_Armature, etc.)
- Available in both the import dialog and **Project Settings → VRM → Import**
- Updated README documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)