### PR TITLE
Distinguish Engine.TimeScale = 0 as paused

### DIFF
--- a/src/spring_bone/godot/vrm_spring_bone_simulation.cpp
+++ b/src/spring_bone/godot/vrm_spring_bone_simulation.cpp
@@ -223,6 +223,9 @@ void VRMSpringBoneSimulation::_process_modification() {
 
   float delta = (float)get_process_delta_time();
   if (delta <= 0.0001f) {
+    if (Engine::get_singleton()->get_time_scale() <= 0.0001) {
+      return;
+    }
     delta = 0.016666f;
   }
 


### PR DESCRIPTION
Makes it so Engine.TimeScale = 0 within Godot pauses springbone simulation instead of falling back to a fixed delta.
Previously, springbones would continue to simulate instead of pausing.